### PR TITLE
Feature/webhook exclusion image upload

### DIFF
--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -37,6 +37,10 @@ class StoreProductRequest extends FormRequest
      */
     public function rules(): array
     {
+        $imageRules = $this->isMethod('post')
+        ? ['required','file','image','mimes:jpeg,png,jpg,gif,svg','max:2048']
+        : ['nullable','file','image','mimes:jpeg,png,jpg,gif,svg','max:2048'];
+
         return [
             'name' => ['required', 'string', 'max:255'],
             'price' => ['required', 'numeric', 'min:0'],
@@ -49,7 +53,7 @@ class StoreProductRequest extends FormRequest
             'product_details.time' => ['required', 'string'],
             'product_details.location' => ['required', 'string'],
             'product_details.category' => ['required', 'string'],
-            'product_details.image' => ['required', 'string'],
+            'product_details.image' => $imageRules,
         ];
     }
 }

--- a/app/Services/ProductManagementService.php
+++ b/app/Services/ProductManagementService.php
@@ -24,15 +24,16 @@ class ProductManagementService
     }
 
     /**
-     * Update a product with the given data.
+     * Update an existing product with its details.
      *
-     * @param  Product  $product
-     * @param  array    $data
-     * @return Product
+     * @param Product $product
+     * @param array $data Validated input from StoreProductRequest.
+     * @return \App\Models\Product
      */
     public function update(Product $product, array $data): Product
     {
         $product->update($data);
+
         return $product->refresh();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
+            "@php artisan storage:link --force"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
@@ -63,6 +64,9 @@
         "test": [
             "@php artisan config:clear --ansi",
             "@php artisan test"
+        ],
+        "post-install-cmd": [
+            "@php artisan storage:link --force"
         ]
     },
     "extra": {

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -30,6 +30,13 @@ return [
 
     'disks' => [
 
+        'images' => [
+            'driver' => 'local',
+            'root'   => storage_path('app/images'),
+            'url'    => env('APP_URL').'/products/images',
+            'visibility' => 'public',
+        ],
+
         'invoices' => [
         'driver' => 'local',
         'root'   => storage_path('app/invoices'),
@@ -80,7 +87,8 @@ return [
     */
 
     'links' => [
-        public_path('storage') => storage_path('app/public'),
+        // public_path('storage') => storage_path('app/public'),
+        public_path('products/images') => storage_path('app/images'),
     ],
 
 ];

--- a/routes/api-payment.php
+++ b/routes/api-payment.php
@@ -17,10 +17,6 @@ Route::prefix('payments')->group(function () {
         ->name('payments.store')
         ->middleware('auth:sanctum');
 
-    // This route is used for the webhook from stripe.
-    Route::post('/webhook', [PaymentController::class, 'webhook'])
-        ->name('payments.webhook');
-
     // This route is used to get the payment status.
     Route::get('/{uuid}', [PaymentController::class, 'showStatus'])
         ->name('payments.showStatus')
@@ -32,6 +28,11 @@ Route::prefix('payments')->group(function () {
         ->middleware('auth:sanctum');
 
 })->middleware(CheckOriginMiddleware::class);
+
+
+// This route is used for the webhook from stripe.
+Route::post('/payments/webhook', [PaymentController::class, 'webhook'])
+    ->name('payments.webhook');
 
 
 Route::prefix('invoices')->group(function () {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1066,9 +1066,70 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/StoreProduct"
+                                "required": [
+                                    "name",
+                                    "price",
+                                    "stock_quantity",
+                                    "product_details[places]",
+                                    "product_details[description]",
+                                    "product_details[date]",
+                                    "product_details[time]",
+                                    "product_details[location]",
+                                    "product_details[category]",
+                                    "product_details[image]"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Sample Product"
+                                    },
+                                    "price": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 49.99
+                                    },
+                                    "sale": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 39.99
+                                    },
+                                    "stock_quantity": {
+                                        "type": "integer",
+                                        "example": 100
+                                    },
+                                    "product_details[places]": {
+                                        "type": "integer",
+                                        "example": 50
+                                    },
+                                    "product_details[description]": {
+                                        "type": "string",
+                                        "example": "A detailed description"
+                                    },
+                                    "product_details[date]": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "2025-05-15"
+                                    },
+                                    "product_details[time]": {
+                                        "type": "string",
+                                        "example": "14:00"
+                                    },
+                                    "product_details[location]": {
+                                        "type": "string",
+                                        "example": "Paris"
+                                    },
+                                    "product_details[category]": {
+                                        "type": "string",
+                                        "example": "Conference"
+                                    },
+                                    "product_details[image]": {
+                                        "type": "file",
+                                        "format": "binary"
+                                    }
+                                },
+                                "type": "object"
                             }
                         }
                     }
@@ -1309,7 +1370,7 @@
                     "Products"
                 ],
                 "summary": "Update product details",
-                "description": "\nUpdates the details of an existing product.\n\n**Requirements**:\n- Bearer authentication (admin only)\n- Valid payload per `StoreProduct` schema\n",
+                "description": "\nUpdates the details of an existing product.\n\n**Requirements**:\n- Bearer authentication (admin only)\n- Valid payload per `StoreProduct` schema\n- The image file is optional and will be stored in the `images` disk.\n- The old image will be deleted if a new one is provided.\n- The product ID must exist in the database.\n",
                 "operationId": "updateProduct",
                 "parameters": [
                     {
@@ -1326,9 +1387,69 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/StoreProduct"
+                                "required": [
+                                    "name",
+                                    "price",
+                                    "stock_quantity",
+                                    "product_details[places]",
+                                    "product_details[description]",
+                                    "product_details[date]",
+                                    "product_details[time]",
+                                    "product_details[location]",
+                                    "product_details[category]"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Sample Product"
+                                    },
+                                    "price": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 49.99
+                                    },
+                                    "sale": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 39.99
+                                    },
+                                    "stock_quantity": {
+                                        "type": "integer",
+                                        "example": 100
+                                    },
+                                    "product_details[places]": {
+                                        "type": "integer",
+                                        "example": 50
+                                    },
+                                    "product_details[description]": {
+                                        "type": "string",
+                                        "example": "A detailed description"
+                                    },
+                                    "product_details[date]": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "2025-05-15"
+                                    },
+                                    "product_details[time]": {
+                                        "type": "string",
+                                        "example": "14:00"
+                                    },
+                                    "product_details[location]": {
+                                        "type": "string",
+                                        "example": "Paris"
+                                    },
+                                    "product_details[category]": {
+                                        "type": "string",
+                                        "example": "Conference"
+                                    },
+                                    "product_details[image]": {
+                                        "type": "file",
+                                        "format": "binary"
+                                    }
+                                },
+                                "type": "object"
                             }
                         }
                     }

--- a/tests/Feature/ProductControllerTest.php
+++ b/tests/Feature/ProductControllerTest.php
@@ -11,6 +11,9 @@ use Tests\TestCase;
 use Mockery;
 use App\Models\User;
 use Laravel\Sanctum\Sanctum;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use App\Services\ProductService;
 
 
 class ProductControllerTest extends TestCase
@@ -80,48 +83,58 @@ class ProductControllerTest extends TestCase
 
     public function testStoreCreatesProduct()
     {
-        // 1) Crée et auth l'utilisateur
+        // 1) On fake le disque 'images'
+        Storage::fake('images');
+
+        // 2) On crée et authentifie un admin
         $user = User::factory()->create(['role' => 'admin']);
         $this->actingAs($user, 'sanctum');
 
-        // 2) Construis un payload valide
-        $base = Product::factory()->make()->only([
-            'name',
-            'price',
-            // ajoute ici tout ce que ta factory cover déjà et qui est dans tes règles
-        ]);
+        // 3) On prépare le payload
+        $base = Product::factory()->make()->only(['name', 'price', 'sale']);
 
-        $data = array_merge($base, [
-            'stock_quantity'   => 50,                       // entier requis
-            'product_details'  => [
-                'description' => 'Une description valide',  // string
+        $file = UploadedFile::fake()->image('product.png');
+
+        $payload = array_merge($base, [
+            'stock_quantity'  => 50,
+            'product_details' => [
+                'description' => 'Une description valide',
                 'date'        => now()->addDay()->toDateString(),
-                'time'        => now()->addHour()->format('H:i:s'), // ex. "14:30:00"
+                'time'        => now()->addHour()->format('H:i:s'),
                 'location'    => 'Paris',
                 'category'    => 'Électronique',
                 'places'      => 10,
-                'image'       => 'https://example.com/img.jpg',
+                'image'       => $file,
             ],
         ]);
 
-        // 3) Mock du ProductManagementService
-        /** @var \Mockery\MockInterface&\App\Services\ProductListingService $managementServiceMock */
-        $managementServiceMock = Mockery::mock(ProductManagementService::class);
-        $managementServiceMock
+        // 4) On mocke le service pour qu'il retourne un Product
+        $serviceMock = Mockery::mock(ProductManagementService::class);
+        $serviceMock
             ->shouldReceive('create')
-            ->with(Mockery::subset($data))
             ->once()
             ->andReturn(new Product());
-        $this->app->instance(ProductManagementService::class, $managementServiceMock);
+        $this->app->instance(ProductManagementService::class, $serviceMock);
 
-        // 4) L’appel authentifié vers l’endpoint
-        $response = $this->postJson('/api/products', $data);
+        // 5) On envoie la requête (Laravel détecte l'UploadedFile et bascule en multipart)
+        $response = $this->post('/api/products', $payload);
 
-        // 5) Assert 201
+        // 6) On vérifie le statut HTTP
         $response->assertStatus(201);
+
+        // 7) On vérifie qu'un seul fichier a bien été stocké
+        $files = Storage::disk('images')->allFiles();
+        $this->assertCount(1, $files, 'On attend exactement un fichier stocké.');
+
+        // 8) On vérifie que ce fichier est bien un .png
+        $filename = basename($files[0]);
+        $this->assertStringEndsWith('.png', $filename);
+
+        // 9) Enfin, on s'assure que le service a bien été appelé
+        Mockery::close();
     }
 
-    public function testUpdateModifiesProduct()
+    public function testUpdateModifiesProductWithoutImage()
     {
         // 1) Crée et auth l’utilisateur admin
         $user = User::factory()->create(['role' => 'admin']);
@@ -130,7 +143,7 @@ class ProductControllerTest extends TestCase
         // 2) Produit existant
         $product = Product::factory()->create();
 
-        // 3) Payload complet (tous les champs requis)
+        // 3) Payload complet (tous les champs sauf 'image')
         $updateData = [
             'name'           => 'Nouveau nom',
             'price'          => 123,
@@ -142,28 +155,86 @@ class ProductControllerTest extends TestCase
                 'location'    => 'Paris',
                 'category'    => 'Électronique',
                 'places'      => 10,
-                'image'       => 'https://example.com/img.jpg',
+                // plus d'image ici : on garde l'ancienne
             ],
         ];
 
-        // 4) Mock du service avec un type matcher pour le Product
-        /** @var \Mockery\MockInterface&\App\Services\ProductListingService $managementServiceMock */
-        $managementServiceMock = Mockery::mock(ProductManagementService::class);
-        $managementServiceMock
+        // 4) Mock du service (vérifie qu'on reçoit bien un Product et $updateData est subset)
+        $serviceMock = Mockery::mock(ProductManagementService::class);
+        $serviceMock
             ->shouldReceive('update')
             ->with(
                 Mockery::type(Product::class),
                 Mockery::subset($updateData)
             )
             ->once()
-            ->andReturn(new Product());
-        $this->app->instance(ProductManagementService::class, $managementServiceMock);
+            ->andReturn($product);
+        $this->app->instance(ProductManagementService::class, $serviceMock);
 
-        // 5) Requête authentifiée
+        // 5) Requête authentifiée en JSON
         $response = $this->putJson("/api/products/{$product->id}", $updateData);
 
-        // 6) On attend bien 204
+        // 6) On attend bien 204 No Content
         $response->assertStatus(204);
+    }
+
+    public function testUpdateReplacesImageAndModifiesProduct()
+    {
+        Storage::fake('images');
+
+        // 1) Admin authentifié
+        $user = User::factory()->create(['role' => 'admin']);
+        Sanctum::actingAs($user, ['*']);
+
+        // 2) Produit existant avec une image initiale
+        $product = Product::factory()->create([
+            'product_details' => [
+                'image' => 'old.png',
+                // autres détails…
+            ],
+        ]);
+        // On crée l'ancienne image sur le disque fake
+        Storage::disk('images')->put('old.png', '');
+
+        // 3) Nouveau fichier à uploader
+        $newFile = UploadedFile::fake()->image('new.png');
+
+        $updateData = [
+            'name'           => 'Nom modifié',
+            'price'          => 200,
+            'stock_quantity' => 5,
+            'product_details' => [
+                'description' => 'Desc mise à jour',
+                'date'        => now()->addDay()->toDateString(),
+                'time'        => now()->addHour()->format('H:i:s'),
+                'location'    => 'Lyon',
+                'category'    => 'Art',
+                'places'      => 20,
+                'image'       => $newFile,
+            ],
+        ];
+
+        // 4) Mock du service (on ne vérifie pas l'image ici)
+        $serviceMock = Mockery::mock(ProductManagementService::class);
+        $serviceMock
+            ->shouldReceive('update')
+            ->once()
+            ->andReturn($product);
+        $this->app->instance(ProductManagementService::class, $serviceMock);
+
+        // 5) Requête multipart
+        $response = $this->put(
+            "/api/products/{$product->id}",
+            $updateData
+        );
+
+        $response->assertStatus(204);
+
+        // 6) L'ancienne doit avoir été supprimée, la nouvelle stockée
+        Storage::disk('images')->assertMissing('old.png');
+        $files = Storage::disk('images')->allFiles();
+        $this->assertCount(1, $files);
+        $this->assertStringEndsWith('.png', basename($files[0]));
     }
 
     public function testGetProductsReturnsProducts()


### PR DESCRIPTION
Cette PR regroupe deux volets :
**Gestion des images produits (store & update)**
- Configuration d’un disque images pointant sur storage/app/images et lien symbolique public/products/images.

**ProductController@store :**
- Upload obligatoire de l’image en multipart/form-data.
- Stockage sur le disque images, conservation du nom de fichier en base.

**ProductController@update :**
- Image optionnelle, suppression de l’ancienne si remplacée.
- Fusion des détails pour ne pas écraser les autres champs.
- FormRequest : règles required en POST et nullable en PUT pour product_details.image.
- Mise à jour des annotations Swagger (@OA\Post, @OA\Put) pour déclarer le multipart et ajuster les champs required.
- Tests unitaires avec Storage::fake() + UploadedFile::fake(), couvrant les scénarios de création, mise à jour sans et avec remplacement d’image.

**Exposition publique du webhook**
- Suppression du middleware d’authentification autour de la route webhook, pour qu’elle soit désormais callable sans passer par CheckOrigin.